### PR TITLE
Fix typo in defining RGB_MATRIX_LIMIT_BRIGHTNESS

### DIFF
--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -81,7 +81,7 @@ __attribute__((weak)) RGB rgb_matrix_hsv_to_rgb(HSV hsv) { return hsv_to_rgb(hsv
 #    if RGB_MATRIX_LIMIT_BRIGHTNESS > UINT8_MAX
 #        define RGB_MATRIX_LIMIT_BRIGHTNESS UINT8_MAX
 #    else
-#        define RGB_MATRIX_LIMIT_BRRIGHTNESS 128
+#        define RGB_MATRIX_LIMIT_BRIGHTNESS 128
 #    endif
 #endif
 


### PR DESCRIPTION
This fixes typo in setting RGB_MATRIX_LIMIT_BRIGHTNESS. Previously, builds
fail when above config is not set. This commit makes the typo fix to set
limit to 128 when limit is not set in config.h

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
